### PR TITLE
Use standard static_assert instead of homemade macro

### DIFF
--- a/src/luabins.c
+++ b/src/luabins.c
@@ -4,6 +4,8 @@
 * See copyright notice in luabins.h
 */
 
+#include <assert.h>
+
 #include "luaheaders.h"
 
 #include "luabins.h"
@@ -72,12 +74,9 @@ LUALIB_API int luaopen_luabins(lua_State * L)
   * Consult PORTABILITY WARNING in saveload.h before changing constants.
   */
 
-  /* int is too small on your platform, fix LUABINS_LINT */
-  luabins_static_assert(sizeof(int) >= LUABINS_LINT);
-  /* size_t is too small on your platform, fix LUABINS_LSIZET */
-  luabins_static_assert(sizeof(size_t) >= LUABINS_LSIZET);
-  /* unexpected lua_Number size, fix LUABINS_LNUMBER */
-  luabins_static_assert(sizeof(lua_Number) == LUABINS_LNUMBER);
+  static_assert(sizeof(int) >= LUABINS_LINT, "int is too small on your platform, fix LUABINS_LINT");
+  static_assert(sizeof(size_t) >= LUABINS_LSIZET, "size_t is too small on your platform, fix LUABINS_LSIZET");
+  static_assert(sizeof(lua_Number) == LUABINS_LNUMBER, "unexpected lua_Number size, fix LUABINS_LNUMBER");
 
   /*
   * Register module

--- a/src/saveload.h
+++ b/src/saveload.h
@@ -19,20 +19,6 @@
 #define luabins_min3(a, b, c) \
   ( ((a) < (b)) ? luabins_min((a), (c)) : luabins_min((b), (c)) )
 
-/* Preprocessor concatenation */
-#define LUABINS_CAT(a, b) a##b
-
-/* Static assert helper macro */
-#define luabins_static_assert_line(pred, line) \
-  typedef char LUABINS_CAT( \
-      static_assertion_failed_at_line_, \
-      line \
-    )[2 * !!(pred) - 1]
-
-/* Static (compile-time) assert */
-#define luabins_static_assert(pred) \
-  luabins_static_assert_line(pred, __LINE__)
-
 /* Internal error codes */
 #define LUABINS_ESUCCESS (0)
 #define LUABINS_EFAILURE (1)


### PR DESCRIPTION
The macros generates misleading warning messages:
```
In file included from /home/travis/build/luabins/src/luabins.c:10:
/home/travis/build/luabins/src/luabins.c: In function ‘luaopen_luabins’:
/home/travis/build/luabins/src/saveload.h:28:7: warning: typedef ‘static_assertion_failed_at_line_76’ locally defined but not used [-Wunused-local-typedefs]
   28 |       static_assertion_failed_at_line_, \
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/travis/build/luabins/src/saveload.h:23:27: note: in definition of macro ‘LUABINS_CAT’
   23 | #define LUABINS_CAT(a, b) a##b
      |                           ^
/home/travis/build/luabins/src/saveload.h:34:3: note: in expansion of macro ‘luabins_static_assert_line’
   34 |   luabins_static_assert_line(pred, __LINE__)
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/travis/build/luabins/src/luabins.c:76:3: note: in expansion of macro ‘luabins_static_assert’
   76 |   luabins_static_assert(sizeof(int) >= LUABINS_LINT);
      |   ^~~~~~~~~~~~~~~~~~~~~
/home/travis/build/luabins/src/saveload.h:28:7: warning: typedef ‘static_assertion_failed_at_line_78’ locally defined but not used [-Wunused-local-typedefs]
   28 |       static_assertion_failed_at_line_, \
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/travis/build/luabins/src/saveload.h:23:27: note: in definition of macro ‘LUABINS_CAT’
   23 | #define LUABINS_CAT(a, b) a##b
      |                           ^
/home/travis/build/luabins/src/saveload.h:34:3: note: in expansion of macro ‘luabins_static_assert_line’
   34 |   luabins_static_assert_line(pred, __LINE__)
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/travis/build/luabins/src/luabins.c:78:3: note: in expansion of macro ‘luabins_static_assert’
   78 |   luabins_static_assert(sizeof(size_t) >= LUABINS_LSIZET);
      |   ^~~~~~~~~~~~~~~~~~~~~
/home/travis/build/luabins/src/saveload.h:28:7: warning: typedef ‘static_assertion_failed_at_line_80’ locally defined but not used [-Wunused-local-typedefs]
   28 |       static_assertion_failed_at_line_, \
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/travis/build/luabins/src/saveload.h:23:27: note: in definition of macro ‘LUABINS_CAT’
   23 | #define LUABINS_CAT(a, b) a##b
      |                           ^
/home/travis/build/luabins/src/saveload.h:34:3: note: in expansion of macro ‘luabins_static_assert_line’
   34 |   luabins_static_assert_line(pred, __LINE__)
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/travis/build/luabins/src/luabins.c:80:3: note: in expansion of macro ‘luabins_static_assert’
   80 |   luabins_static_assert(sizeof(lua_Number) == LUABINS_LNUMBER);
      |   ^~~~~~~~~~~~~~~~~~~~~
```